### PR TITLE
Add Toast to Remove Collaborator Image Button Long Click

### DIFF
--- a/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/CollaboratorsActivity.kt
@@ -85,7 +85,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
     private fun ActivityCollaboratorsBinding.setupViews() {
         setupToolbar()
 
-        collaboratorsList.adapter = CollaboratorsAdapter(viewModel::clickRemoveCollaborator)
+        collaboratorsList.adapter = CollaboratorsAdapter(viewModel::clickRemoveCollaborator, viewModel::longClickRemoveCollaborator)
         collaboratorsList.isNestedScrollingEnabled = false
         collaboratorsList.layoutManager = LinearLayoutManager(this@CollaboratorsActivity)
         collaboratorsList.setEmptyView(empty.root)
@@ -134,6 +134,7 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
             when (event) {
                 is Event.AddCollaboratorEvent -> showAddCollaboratorFragment(event)
                 is Event.LongAddCollaboratorEvent -> showLongAddToast()
+                is Event.LongRemoveCollaboratorEvent -> showLongRemoveToast()
                 is Event.RemoveCollaboratorEvent -> showRemoveCollaboratorDialog(event)
                 Event.CloseCollaboratorsEvent -> finish()
             }
@@ -145,6 +146,14 @@ class CollaboratorsActivity : ThemedAppCompatActivity() {
             buttonAddCollaborator.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
         }
         toast(R.string.add_collaborator)
+    }
+
+    private fun ActivityCollaboratorsBinding.showLongRemoveToast() {
+        if (buttonAddCollaborator.isHapticFeedbackEnabled) {
+            buttonAddCollaborator.performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+        }
+
+        toast(R.string.remove_collaborator)
     }
 
     private fun ActivityCollaboratorsBinding.handleCollaboratorsList(collaborators: List<String>) {

--- a/Simplenote/src/main/java/com/automattic/simplenote/utils/CollaboratorsAdapter.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/utils/CollaboratorsAdapter.kt
@@ -10,6 +10,7 @@ import com.automattic.simplenote.databinding.CollaboratorsHeaderBinding
 
 class CollaboratorsAdapter(
     private val onDeleteClick: (collaborator: String) -> Unit,
+    private val onDeleteLongClick: () -> Unit,
 ) : ListAdapter<CollaboratorsAdapter.CollaboratorDataItem, RecyclerView.ViewHolder>(DIFF_CALLBACK) {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
@@ -20,7 +21,7 @@ class CollaboratorsAdapter(
             }
             ITEM_VIEW_TYPE_ITEM -> {
                 val binding = CollaboratorRowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-                CollaboratorViewHolder(binding, onDeleteClick)
+                CollaboratorViewHolder(binding, onDeleteClick, onDeleteLongClick)
             }
             else -> throw ClassCastException("Unknown viewType $viewType")
         }
@@ -55,12 +56,17 @@ class CollaboratorsAdapter(
 
     class CollaboratorViewHolder(
         private val binding: CollaboratorRowBinding,
-        private val onDeleteClick: (collaborator: String) -> Unit
+        private val onDeleteClick: (collaborator: String) -> Unit,
+        private val onDeleteLongClick: () -> Unit
     ): RecyclerView.ViewHolder(binding.root) {
 
         fun bind(collaborator: CollaboratorDataItem.CollaboratorItem) {
             binding.collaboratorText.text = collaborator.email
             binding.collaboratorRemoveButton.setOnClickListener { onDeleteClick(collaborator.email) }
+            binding.collaboratorRemoveButton.setOnLongClickListener {
+                onDeleteLongClick()
+                true
+            }
         }
     }
 

--- a/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
+++ b/Simplenote/src/main/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModel.kt
@@ -9,7 +9,6 @@ import com.automattic.simplenote.repositories.CollaboratorsActionResult
 import com.automattic.simplenote.repositories.CollaboratorsRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -70,6 +69,10 @@ class CollaboratorsViewModel @Inject constructor(
         _event.value = Event.RemoveCollaboratorEvent(collaborator)
     }
 
+    fun longClickRemoveCollaborator() {
+        _event.postValue(Event.LongRemoveCollaboratorEvent)
+    }
+
     fun close() {
         _event.value = Event.CloseCollaboratorsEvent
     }
@@ -107,6 +110,7 @@ class CollaboratorsViewModel @Inject constructor(
         data class AddCollaboratorEvent(val noteId: String) : Event()
         object CloseCollaboratorsEvent : Event()
         object LongAddCollaboratorEvent : Event()
+        object LongRemoveCollaboratorEvent : Event()
         data class RemoveCollaboratorEvent(val collaborator: String) : Event()
     }
 }

--- a/Simplenote/src/main/res/layout/collaborator_row.xml
+++ b/Simplenote/src/main/res/layout/collaborator_row.xml
@@ -25,7 +25,7 @@
 
     <ImageButton
         android:id="@+id/collaborator_remove_button"
-        android:background="?attr/selectableItemBackgroundBorderless"
+        android:background="?attr/actionBarItemBackground"
         android:contentDescription="@string/remove_collaborator"
         android:focusable="false"
         android:focusableInTouchMode="false"

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/CollaboratorsViewModelTest.kt
@@ -143,6 +143,13 @@ class CollaboratorsViewModelTest {
     }
 
     @Test
+    fun longClickRemoveCollaboratorShouldTriggerLongRemoveCollaboratorEvent() {
+        viewModel.longClickRemoveCollaborator()
+
+        assertEquals(viewModel.event.value, Event.LongRemoveCollaboratorEvent)
+    }
+
+    @Test
     fun closeShouldTriggerCloseCollaborators() {
         viewModel.close()
 

--- a/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
+++ b/Simplenote/src/test/java/com/automattic/simplenote/viewmodels/TagsViewModelTest.kt
@@ -151,7 +151,7 @@ class TagsViewModelTest {
     }
 
     @Test
-    fun lonClickAddTagShouldTriggerLongAddTagEvent() {
+    fun longClickAddTagShouldTriggerLongAddTagEvent() {
         viewModel.longClickAddTag()
 
         assertEquals(viewModel.event.value, TagsEvent.LongAddTagEvent)


### PR DESCRIPTION
### Fix
Add a toast message to the ***Remove Collaborator*** image button long click for each collaborator item on the ***Collaborators*** screen.  The behavior and test mimic the existing ***Delete Tag*** image button long click on the ***Edit Tags*** screen.  See the screenshots and videos below for illustration.

> [!WARNING]
> The screenshot composite is a large image, 2280 pixels × 9996 pixels, and may take a while to load.

<details>
    <summary>
        <h3>Screenshots</h3>
    </summary>
    <img alt="Before and After Screenshots of Collaborators Screen While Long-Pressing Remove Collaborator Image Button in Dark and Light Modes" src="https://github.com/user-attachments/assets/bf7b0a17-48fb-4e6e-a2f2-01ea386ec5f8" />
</details>

<details>
    <summary>
        <h3>Videos</h3>
    </summary>
    <table>
        <tr>
            <th>Dark</th>
            <th>Light</th>
        </tr>
        <tr>
            <td><video src="https://github.com/user-attachments/assets/f5b85bda-d70e-4366-9adf-b414a6164961" /></td>
            <td><video src="https://github.com/user-attachments/assets/fd6a5438-701d-42af-8ab1-f5dd8ddcbb71" /></td>
        </tr>
    </table>
</details>

Relates: https://github.com/Automattic/simplenote-android/issues/1752

> [!NOTE]
> This pull request targets the `theck13:heck/add-collaborator-toast` branch to avoid merge conflicts and to isolate the changes for easier review.  Merge the pull request associated with that branch, https://github.com/Automattic/simplenote-android/pull/1753, first.

### Test
1. Tap any note in list with at least one collaborator.
2. Tap ellipsis/overflow icon in top app bar.
3. Tap ***Collaborators*** item in menu.
4. Long-press ***Remove Collaborator*** image button for any collaborator.
5. Notice touch feedback is not clipped.
6. Notice ***Remove Collaborator*** toast.

### Review
Only one developer is required to review these changes, but anyone can perform the review.

### Release
These changes do not require release notes.